### PR TITLE
fix: withdraw button is disabled on legacy LP Vaults

### DIFF
--- a/src/components/Vault/ActiveDeposit.tsx
+++ b/src/components/Vault/ActiveDeposit.tsx
@@ -65,12 +65,10 @@ const ActiveDeposit = ({
             loading && actionType === ACTIVE_VAULT_DEPOSIT_ACTIONS.WITHDRAW
           }
           disabled={
-            isLegacyLPVault
-              ? false
-              : isLegacyVault ||
-                loading ||
-                !accountData?.address ||
-                Number(userVaultBalance) === 0
+            (isLegacyVault && !isLegacyLPVault) ||
+            loading ||
+            !accountData?.address ||
+            Number(userVaultBalance) === 0
           }
         >
           Withdraw

--- a/src/components/Vault/ActiveDeposit.tsx
+++ b/src/components/Vault/ActiveDeposit.tsx
@@ -65,10 +65,12 @@ const ActiveDeposit = ({
             loading && actionType === ACTIVE_VAULT_DEPOSIT_ACTIONS.WITHDRAW
           }
           disabled={
-            isLegacyVault ||
-            loading ||
-            !accountData?.address ||
-            Number(userVaultBalance) === 0
+            isLegacyLPVault
+              ? false
+              : isLegacyVault ||
+                loading ||
+                !accountData?.address ||
+                Number(userVaultBalance) === 0
           }
         >
           Withdraw

--- a/src/constants/vaults.ts
+++ b/src/constants/vaults.ts
@@ -8,7 +8,7 @@ export interface VaultProps {
   token1?: string
   isActive?: boolean
   isLegacyVault?: boolean //for disabling APR, Deposit and Input button, Withdraw Buton and Claims Button for Legacy Vaults (Single-Side and LP Vaults)
-  isLegacyLPVault?: boolean //for disabling APR, Deposit and Input button, Rewards Column to 0, Withdraw, Claims, Withdraw and Claims buttons for Legacy LP Vaults
+  isLegacyLPVault?: boolean //for disabling APR, Deposit and Input button, Rewards Column to 0, Claims, Withdraw and Claims buttons for Legacy LP Vaults
 }
 
 export interface VaultsProps {


### PR DESCRIPTION
## What changes

- re-enable withdraw buttons for all legacy LP Vaults

## Anything to note for reviewers?

-

## Screenshots (if applicable)

-

## Issues

-

## Resolves

- Resolves #23


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202719969977642