### PR TITLE
feat: add the api endpoint to return latest locked newo

### DIFF
--- a/src/lib/utils/venewo.ts
+++ b/src/lib/utils/venewo.ts
@@ -1,0 +1,36 @@
+import { ethers } from 'ethers'
+
+import { contractAddresses } from 'constants/contractAddresses'
+import { SUPPORTED_NETWORKS } from 'constants/network'
+
+import veTokenAbi from 'contracts/abi/veToken.json'
+
+export const getTotalLockedNewo = async () => {
+  // Fetches the locked newo from our supported networks
+  // Returns the combined value
+  const networks = SUPPORTED_NETWORKS.filter((network) => {
+    return !network.testnet && network
+  })
+
+  let totalLocked = 0
+
+  for (let index = 0; index < networks.length; index++) {
+    const provider = new ethers.providers.JsonRpcProvider(
+      networks[index].rpcUrls.default
+    )
+    const veNewoAddress = contractAddresses[networks[index].id].VENEWO
+    const veNewoInstance = new ethers.Contract(
+      veNewoAddress,
+      veTokenAbi,
+      provider
+    )
+    const decimals = await veNewoInstance.decimals()
+
+    // Get the totalAssets and add to totalLocked
+    const totalAssets = await veNewoInstance.totalAssets()
+    const formattedTotalAssets = ethers.utils.formatUnits(totalAssets, decimals)
+    totalLocked += Number(formattedTotalAssets)
+  }
+
+  return totalLocked
+}


### PR DESCRIPTION
## What changes
- add option to use query params on the `locked-newo` endpoint
- move the function to compute total locked newo in `getTotalLockedNewo` under `lib/utils`

## Notes for Reviewers
- Visit `/api/locked-newo?latest=true` to get the value


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203277982270856