### PR TITLE
chore: add tooltip on the venewo register button to inform users to re-register

### DIFF
--- a/src/components/VeNewo/RegistrationReward.tsx
+++ b/src/components/VeNewo/RegistrationReward.tsx
@@ -29,7 +29,7 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
 }) => {
   const router = useRouter()
   const { address } = useAccount()
-  const { multiplier, unlockDate } = useVeNewoContext()
+  const { multiplier, unlockDate, balance: veNewoBalance } = useVeNewoContext()
   const veVault = useVeVault(veVaultAddress, tokenAddress, token0, token1)
   const token = useToken(tokenAddress)
   const [boost, setBoost] = useState('1.00')
@@ -109,7 +109,12 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
                 <Button
                   onClick={register}
                   isLoading={veVault.loading}
-                  isDisabled={!address || isRegistered || veVault.loading}
+                  isDisabled={
+                    !address ||
+                    isRegistered ||
+                    veVault.loading ||
+                    Number(veNewoBalance) === 0
+                  }
                   variant="greenButton"
                 >
                   {isRegistered ? 'Registered' : 'Register'}

--- a/src/components/VeNewo/RegistrationReward.tsx
+++ b/src/components/VeNewo/RegistrationReward.tsx
@@ -103,7 +103,7 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
             )}
             {actions.includes('register') && (
               <Tooltip
-                label="You have updated your veNEWO lock information and will need to register again"
+                label="You have updated your veNEWO lock information and will need to register for rewards"
                 isDisabled={isRegistered || !!!unlockDate}
               >
                 <Button

--- a/src/components/VeNewo/RegistrationReward.tsx
+++ b/src/components/VeNewo/RegistrationReward.tsx
@@ -1,4 +1,4 @@
-import { Button, HStack } from '@chakra-ui/react'
+import { Button, HStack, Tooltip } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
 import { useAccount } from 'wagmi'
 import { useRouter } from 'next/router'
@@ -58,6 +58,8 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
           const dueDate = accounts?.dueDate?.toNumber()
           if (dueDate === unlockDate && unlockDate !== 0 && dueDate !== 0) {
             setIsRegistered(true)
+          } else {
+            setIsRegistered(false)
           }
         }
       } else {
@@ -100,15 +102,21 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
               </Button>
             )}
             {actions.includes('register') && (
-              <Button
-                onClick={register}
-                isLoading={veVault.loading}
-                disabled={!address || isRegistered || veVault.loading}
-                isDisabled={veVault.loading}
-                variant="greenButton"
+              <Tooltip
+                label="You have updated your veNEWO lock information and will need to register again"
+                isDisabled={isRegistered || !!!unlockDate}
               >
-                {isRegistered ? 'Registered' : 'Register'}
-              </Button>
+                <Button
+                  onClick={register}
+                  isLoading={veVault.loading}
+                  isDisabled={
+                    !address || isRegistered || veVault.loading || !!!unlockDate
+                  }
+                  variant="greenButton"
+                >
+                  {isRegistered ? 'Registered' : 'Register'}
+                </Button>
+              </Tooltip>
             )}
           </HStack>
         </Td>

--- a/src/components/VeNewo/RegistrationReward.tsx
+++ b/src/components/VeNewo/RegistrationReward.tsx
@@ -76,7 +76,7 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
   useEffect(() => {
     checkRegistrationStatus()
     // eslint-disable-next-line
-  }, [multiplier, boost, unlockDate, address])
+  }, [multiplier, boost, unlockDate, address, veVault])
 
   const register = async () => {
     await veVault.notifyDeposit()
@@ -109,9 +109,7 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
                 <Button
                   onClick={register}
                   isLoading={veVault.loading}
-                  isDisabled={
-                    !address || isRegistered || veVault.loading || !!!unlockDate
-                  }
+                  isDisabled={!address || isRegistered || veVault.loading}
                   variant="greenButton"
                 >
                   {isRegistered ? 'Registered' : 'Register'}

--- a/src/components/VeNewo/RegistrationReward.tsx
+++ b/src/components/VeNewo/RegistrationReward.tsx
@@ -50,7 +50,10 @@ const RegistrationReward: React.FC<RegistrationRewardProps> = ({
   const checkRegistrationStatus = async () => {
     if (address) {
       if (token0 && token1 && Number(multiplier) === Number(boost)) {
-        setIsRegistered(true)
+        const assetBalance = await veVault.assetBalanceOf(address)
+        if (Number(assetBalance) > 0) {
+          setIsRegistered(true)
+        }
       } else if (!token0 && !token1) {
         const accounts = await veVault?.accounts(address)
 


### PR DESCRIPTION
## What changes
- disable register button when no veNEWO is locked

## Anything to note for reviewers?
-

## Screenshots (if applicable)
-

## Issues
-




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203749103971700