### PR TITLE
fix: multiplier and unlock date not updating on wallet change

### DIFF
--- a/src/components/VeNewo/LockForm.tsx
+++ b/src/components/VeNewo/LockForm.tsx
@@ -92,6 +92,9 @@ const LockForm = () => {
       const newMinLockTime = dayjs.unix(unlockDate).add(10, 'second').toDate()
       setLockTime(newMinLockTime)
       setMinLockTime(newMinLockTime)
+    } else {
+      setLockTime(dayjs().add(91, 'd').toDate())
+      setMinLockTime(dayjs().add(91, 'd').toDate())
     }
     // eslint-disable-next-line
   }, [unlockDate])

--- a/src/store/contexts/veNewoContext.tsx
+++ b/src/store/contexts/veNewoContext.tsx
@@ -1,4 +1,10 @@
-import { createContext, useContext, useEffect, useReducer } from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useReducer,
+} from 'react'
 import { useAccount, useNetwork } from 'wagmi'
 import { ethers } from 'ethers'
 
@@ -134,7 +140,7 @@ export const VeNewoProvider: React.FC<VeNewoProviderProps> = ({ children }) => {
     }
   }
 
-  const updateMultiplier = async () => {
+  const updateMultiplier = useCallback(async () => {
     if (accountAddress) {
       const balance = await veNewo.balanceOf(accountAddress)
       const assetBalance = await veNewo.assetBalanceOf(accountAddress)
@@ -145,9 +151,14 @@ export const VeNewoProvider: React.FC<VeNewoProviderProps> = ({ children }) => {
           type: UPDATE_MULTIPLIER,
           payload: Number(multiplier).toFixed(2),
         })
+      } else {
+        dispatch({
+          type: UPDATE_MULTIPLIER,
+          payload: Number(0).toFixed(2),
+        })
       }
     }
-  }
+  }, [accountAddress, veNewo])
 
   const updateState = async () => {
     Promise.all([


### PR DESCRIPTION
## What changes

- [fix: value of multiplier not updating after wallet change](https://github.com/new-order-network/new-order-app-ui/commit/bac8e5232b4c892ccc8399732058c45f88a4c7a0)

- [fix: unlock date not updating after wallet change](https://github.com/new-order-network/new-order-app-ui/commit/c4ec6bcb2585e3bbd60a412b36659cd49ba15ccd)

## How to Check Issue
1. Connect wallet to new order dapp.
2. Note of the multiplier and unlock date values from the venewo page from `My Positions` and the lock form input.
3. Change wallet account.
4. Value of multiplier and should update now, previously not updating.