### PR TITLE
fix: app crash when trying to access the app with the wrong chain

### DIFF
--- a/src/store/contexts/contractContext.tsx
+++ b/src/store/contexts/contractContext.tsx
@@ -72,7 +72,7 @@ export const ContractProvider: React.FC<ContractProviderProps> = ({
   const [hasNetworkError, setHasNetworkError] = useState(false)
 
   useEffect(() => {
-    if (chain?.id) {
+    if (chain?.id && isChainSupported(chain.id)) {
       setContracts(contractAddresses[chain.id])
       setVaults(Vaults[chain.id])
       setAirdrops(Airdrops[chain.id])


### PR DESCRIPTION
## What changes
- add a check to see if we support the chain
- prevent contracts from changing if the chain is unsupported


