### PR TITLE
chore: force zero apr on the avax lp vault

### DIFF
--- a/src/hooks/useVeVault.ts
+++ b/src/hooks/useVeVault.ts
@@ -10,6 +10,7 @@ import { getTokenPriceByAddress } from 'lib/utils/tokens'
 
 import { useNewoContext } from 'store/contexts/newoContext'
 import { useVeNewoContext } from 'store/contexts/veNewoContext'
+import { useContractContext } from 'store/contexts/contractContext'
 
 import { YEAR_IN_SECONDS } from 'constants/numbers'
 
@@ -46,6 +47,9 @@ const useVeVault = (
   token0?: `0x${string}`,
   token1?: `0x${string}`
 ): UseVeVaultProps => {
+  // TODO: to be removed
+  const { contracts } = useContractContext()
+
   const toast = useToast()
   const { data: signer } = useSigner()
   const { chain } = useNetwork()
@@ -112,6 +116,12 @@ const useVeVault = (
             YEAR_IN_SECONDS *
             100) /
           lpTvl
+
+        // TODO: to be removed
+        // NOTE; forces the apr to be 0 when it's the avax lp vault
+        if (vaultAddress === contracts.VE_NEWO_WAVAX_LP_VAULT) {
+          calculatedApr = 0
+        }
       } else {
         const rewardRate = await veVaultInstance.rewardRate()
         const convertedRewardRate = Number(


### PR DESCRIPTION
- force the lp vault to temporarily show 0 on the apr
- add TODOs on the lines that should be removed when reverting this

![image](https://user-images.githubusercontent.com/46964393/218444251-3c3be635-9fa9-4695-9b72-9a6eaf926b14.png)
