### PR TITLE
Feat/integrate youtube channel

### DIFF
--- a/src/api/youtubeApi.ts
+++ b/src/api/youtubeApi.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+// TODO: change API key and playlist ID with the New Order DAO channel ID
+const googleApiKey = ''
+const playlistId = ''
+
+const youtubeApi = axios.create({
+  baseURL: `https://www.googleapis.com/youtube/v3/playlistItems?&playlistId=${playlistId}&part=snippet&maxResults=50&key=${googleApiKey}`,
+  withCredentials: false,
+})
+
+export default youtubeApi

--- a/src/components/NewsFeed.tsx
+++ b/src/components/NewsFeed.tsx
@@ -119,9 +119,10 @@ const NewsFeed = () => {
             dateTime: article.snippet.publishedAt,
             webLink: `https://www.youtube.com/watch?v=${article.snippet.resourceId.videoId}`,
             mediaLink: article.snippet.thumbnails.medium.url,
-            description: removeMd(article.snippet.description)
-              .replace('\n', ' ')
-              .substring(0, 200),
+            description: removeMd(article.snippet.description).replace(
+              '\n',
+              ' '
+            ),
             type: NEWS_TYPES.VIDEO,
             refSource: 'Youtube',
           }

--- a/src/components/NewsFeed.tsx
+++ b/src/components/NewsFeed.tsx
@@ -19,12 +19,14 @@ import NewsLoader from 'components/Loaders/NewsLoader'
 
 import mediumApi from 'api/mediumApi'
 import frogsAnonymousApi from 'api/frogsAnonymousApi'
+import youtubeApi from 'api/youtubeApi'
 
 import { NEWS_TYPES } from 'models/types'
 import {
   ArticleProps,
   FrogsAnonymousArticleProps,
   MediumArticleProps,
+  YoutubeArticleProps,
 } from 'models/article'
 
 import NewsFeedIcon from 'assets/icons/NewsFeed.svg'
@@ -101,8 +103,40 @@ const NewsFeed = () => {
         console.error('[NEWSFEED ERROR]', err)
       })
 
+    const youtubeVideos = await youtubeApi
+      .get('')
+      .then((res) => {
+        const data = res.data.items
+
+        if (!data) {
+          return null
+        }
+
+        return data.map((article: YoutubeArticleProps) => {
+          return {
+            id: article.id,
+            title: article.snippet.title,
+            dateTime: article.snippet.publishedAt,
+            webLink: `https://www.youtube.com/watch?v=${article.snippet.resourceId.videoId}`,
+            mediaLink: article.snippet.thumbnails.medium.url,
+            description: removeMd(article.snippet.description)
+              .replace('\n', ' ')
+              .substring(0, 200),
+            type: NEWS_TYPES.VIDEO,
+            refSource: 'Youtube',
+          }
+        })
+      })
+      .catch((err) => {
+        console.error('[NEWSFEED ERROR]', err)
+      })
+
     // Combine all articles
-    const allArticles = [...newOrderMediumContent, ...(frogsAnonContent as [])]
+    const allArticles = [
+      ...newOrderMediumContent,
+      ...(frogsAnonContent as []),
+      ...youtubeVideos,
+    ]
 
     // Sort date from latest to oldest
     const sortedByDate = allArticles.sort(function (a, b) {
@@ -180,13 +214,14 @@ const NewsFeed = () => {
         >
           <TabPanels w="full">
             <TabPanel>
-              {/* TODO UPDATE SO IT WILL ALSO INCLUDE VIDEO HERE */}
-
               {isNewsLoading
                 ? newLoader()
                 : articles
                     ?.filter((article: ArticleProps) => {
-                      return article.type === NEWS_TYPES.ARTICLE
+                      return (
+                        article.type === NEWS_TYPES.ARTICLE ||
+                        article.type === NEWS_TYPES.VIDEO
+                      )
                     })
                     ?.map((article: ArticleProps) => {
                       return <NewsCard key={article.id} news={article} />

--- a/src/models/article.ts
+++ b/src/models/article.ts
@@ -52,6 +52,29 @@ export interface MediumArticleProps {
   description: string
 }
 
+export interface YoutubeVideoSnippet {
+  publishedAt: string
+  title: string
+  description: string
+  thumbnails: {
+    medium: YoutubeThumbnail
+  }
+  resourceId: {
+    videoId: string
+  }
+}
+
+export interface YoutubeThumbnail {
+  url: string
+  width: number
+  height: number
+}
+
+export interface YoutubeArticleProps {
+  id: string
+  snippet: YoutubeVideoSnippet
+}
+
 export interface ArticleProps {
   id: string
   title: string


### PR DESCRIPTION
## What changes

Integrate Youtube channel into the main page under "Videos" tab in the news feed

## Anything to note for reviewers?

- You need to add a Google API key and the playlist ID of the channel. You can find the ID of the Youtube channel (e.g. "UC_x5XG1OV2P6uZZ5FSM9Ttw") and then just change the second letter to U, so it reads "UU_x5XG1OV2P6uZZ5FSM9Ttw" instead.

## Screenshots (if applicable)

-

## Issues

-

## Resolves

- Resolves [https://app.dework.xyz/new-order/technicalengineerin?taskId=2ace4d05-b22a-47ff-b605-e948b1994db1](https://app.dework.xyz/new-order/technicalengineerin?taskId=2ace4d05-b22a-47ff-b605-e948b1994db1
)