### PR TITLE
fix: incorrect voting status

### DIFF
--- a/src/components/Voting/VotingCard.tsx
+++ b/src/components/Voting/VotingCard.tsx
@@ -34,20 +34,33 @@ const VotingCard: React.FC<VotingCardProps> = ({
     }
   }, [choices, scores, state])
 
+  const buttonVariant = (buttonState: string) => {
+    if (buttonState === VotingStatus.PENDING) {
+      return 'outlineGray'
+    } else if (buttonState === VotingStatus.ACTIVE) {
+      return 'greenSmallButton'
+    } else {
+      return 'outlinePurple'
+    }
+  }
+
   return (
     <Card variant="simple">
       <Link href={`/voting/${id}`}>
         <>
           <Flex alignItems="center" justifyContent="space-between">
             <Text color="gray.50" fontSize="xs">
-              Status
+              {state === VotingStatus.CLOSED ? 'Result' : 'Status'}
             </Text>
             <Button
               fontSize="0.75rem"
               h="6"
               fontWeight="bold"
-              variant={state === 'active' ? 'greenSmallButton' : 'outlineGreen'}
+              variant={buttonVariant(state)}
               textTransform="uppercase"
+              _hover={{
+                bgColor: 'none',
+              }}
             >
               {stateText}
             </Button>

--- a/src/components/Voting/VotingCard.tsx
+++ b/src/components/Voting/VotingCard.tsx
@@ -29,7 +29,7 @@ const VotingCard: React.FC<VotingCardProps> = ({
       } else if (choices[highestVotedIndex] === VotingChoices.AGAINST) {
         setStateText(VotingOutcomes.FAILED)
       } else {
-        setStateText(VotingOutcomes.ABSTAINED)
+        setStateText(choices[highestVotedIndex])
       }
     }
   }, [choices, scores, state])

--- a/src/components/Voting/VotingStatusFilter.tsx
+++ b/src/components/Voting/VotingStatusFilter.tsx
@@ -2,8 +2,6 @@ import { Button, Text } from '@chakra-ui/react'
 
 import {
   VotingProposalProps,
-  VotingStatusOrOutcome,
-  VotingChoices,
   VotingStatus,
   VotingStatusChoices,
 } from 'models/voting'
@@ -23,33 +21,10 @@ const VotingStatusFilter: React.FC<VotingStatusFilterProps> = ({
     return (
       votingProposals &&
       votingProposals.filter((proposal: VotingProposalProps) => {
-        if (
-          status === VotingStatusOrOutcome.CLOSED ||
-          status === VotingStatusOrOutcome.ACTIVE
-        ) {
-          return proposal.state === status
-        } else if (status !== VotingStatusOrOutcome.ALL && proposal.scores) {
-          const highestVotedIndex = proposal.scores.indexOf(
-            Math.max(...proposal.scores)
-          )
-          if (status === VotingStatusOrOutcome.PASSED) {
-            return (
-              proposal.state === VotingStatus.CLOSED &&
-              proposal.choices[highestVotedIndex] === VotingChoices.FOR
-            )
-          } else if (status === VotingStatusOrOutcome.FAILED) {
-            return (
-              proposal.state === VotingStatus.CLOSED &&
-              proposal.choices[highestVotedIndex] === VotingChoices.AGAINST
-            )
-          } else {
-            return (
-              proposal.state === VotingStatus.CLOSED &&
-              proposal.choices[highestVotedIndex] === VotingChoices.ABSTAIN
-            )
-          }
-        } else {
+        if (status === VotingStatus.ALL) {
           return proposal
+        } else {
+          return proposal.state === status
         }
       })?.length
     )
@@ -63,106 +38,53 @@ const VotingStatusFilter: React.FC<VotingStatusFilterProps> = ({
         h="6"
         fontWeight="bold"
         variant={
-          status === VotingStatusOrOutcome.ALL
-            ? 'greenSmallButton'
-            : 'outlineGreen'
+          status === VotingStatus.ALL ? 'greenSmallButton' : 'outlineGreen'
         }
         onClick={() => {
-          return setStatus(VotingStatusOrOutcome.ALL)
+          return setStatus(VotingStatus.ALL)
         }}
       >
-        All{' '}
-        <Text ml="2">{countProposalsByStatus(VotingStatusOrOutcome.ALL)}</Text>
+        All <Text ml="2">{countProposalsByStatus(VotingStatus.ALL)}</Text>
       </Button>
       <Button
         fontSize="0.75rem"
         h="6"
         fontWeight="bold"
         variant={
-          status === VotingStatusOrOutcome.ACTIVE
-            ? 'greenSmallButton'
-            : 'outlineGreen'
+          status === VotingStatus.ACTIVE ? 'greenSmallButton' : 'outlineGreen'
         }
         onClick={() => {
-          return setStatus(VotingStatusOrOutcome.ACTIVE)
+          return setStatus(VotingStatus.ACTIVE)
         }}
       >
-        Active{' '}
-        <Text ml="2">
-          {countProposalsByStatus(VotingStatusOrOutcome.ACTIVE)}
-        </Text>
+        Active <Text ml="2">{countProposalsByStatus(VotingStatus.ACTIVE)}</Text>
       </Button>
       <Button
         fontSize="0.75rem"
         h="6"
         fontWeight="bold"
         variant={
-          status === VotingStatusOrOutcome.CLOSED
-            ? 'greenSmallButton'
-            : 'outlineGreen'
+          status === VotingStatus.PENDING ? 'greenSmallButton' : 'outlineGreen'
         }
         onClick={() => {
-          return setStatus(VotingStatusOrOutcome.CLOSED)
+          return setStatus(VotingStatus.PENDING)
         }}
       >
-        Closed{' '}
-        <Text ml="2">
-          {countProposalsByStatus(VotingStatusOrOutcome.CLOSED)}
-        </Text>
+        Pending{' '}
+        <Text ml="2">{countProposalsByStatus(VotingStatus.PENDING)}</Text>
       </Button>
       <Button
         fontSize="0.75rem"
         h="6"
         fontWeight="bold"
         variant={
-          status === VotingStatusOrOutcome.PASSED
-            ? 'greenSmallButton'
-            : 'outlineGreen'
+          status === VotingStatus.CLOSED ? 'greenSmallButton' : 'outlineGreen'
         }
         onClick={() => {
-          return setStatus(VotingStatusOrOutcome.PASSED)
+          return setStatus(VotingStatus.CLOSED)
         }}
       >
-        Passed{' '}
-        <Text ml="2">
-          {countProposalsByStatus(VotingStatusOrOutcome.PASSED)}
-        </Text>
-      </Button>
-      <Button
-        fontSize="0.75rem"
-        h="6"
-        fontWeight="bold"
-        variant={
-          status === VotingStatusOrOutcome.FAILED
-            ? 'greenSmallButton'
-            : 'outlineGreen'
-        }
-        onClick={() => {
-          return setStatus(VotingStatusOrOutcome.FAILED)
-        }}
-      >
-        Failed{' '}
-        <Text ml="2">
-          {countProposalsByStatus(VotingStatusOrOutcome.FAILED)}
-        </Text>
-      </Button>
-      <Button
-        fontSize="0.75rem"
-        h="6"
-        fontWeight="bold"
-        variant={
-          status === VotingStatusOrOutcome.ABSTAINED
-            ? 'greenSmallButton'
-            : 'outlineGreen'
-        }
-        onClick={() => {
-          return setStatus(VotingStatusOrOutcome.ABSTAINED)
-        }}
-      >
-        Abstained{' '}
-        <Text ml="2">
-          {countProposalsByStatus(VotingStatusOrOutcome.ABSTAINED)}
-        </Text>
+        Closed <Text ml="2">{countProposalsByStatus(VotingStatus.CLOSED)}</Text>
       </Button>
     </>
   )

--- a/src/components/__tests__/__snapshots__/VotingCard.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/VotingCard.test.tsx.snap
@@ -18,10 +18,10 @@ exports[`VotingCard.tsx component match to snapshot 1`] = `
           <p
             class="chakra-text css-1ykficz"
           >
-            Status
+            Result
           </p>
           <button
-            class="chakra-button css-zhj3hh"
+            class="chakra-button css-8b9qsq"
             type="button"
           />
         </div>

--- a/src/components/__tests__/__snapshots__/VotingCard.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/VotingCard.test.tsx.snap
@@ -23,9 +23,7 @@ exports[`VotingCard.tsx component match to snapshot 1`] = `
           <button
             class="chakra-button css-zhj3hh"
             type="button"
-          >
-            ABSTAINED
-          </button>
+          />
         </div>
         <div
           class="css-icjpl3"

--- a/src/components/__tests__/__snapshots__/VotingStatusFilter.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/VotingStatusFilter.test.tsx.snap
@@ -11,8 +11,7 @@ exports[`VotingStatusFilter.tsx component match to snapshot all active proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    All
-     
+    All 
     <p
       class="chakra-text css-14gt3bc"
     >
@@ -23,8 +22,7 @@ exports[`VotingStatusFilter.tsx component match to snapshot all active proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    Active
-     
+    Active 
     <p
       class="chakra-text css-14gt3bc"
     >
@@ -35,48 +33,23 @@ exports[`VotingStatusFilter.tsx component match to snapshot all active proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    Closed
+    Pending
      
+    <p
+      class="chakra-text css-14gt3bc"
+    >
+      0
+    </p>
+  </button>
+  <button
+    class="chakra-button css-19xffvm"
+    type="button"
+  >
+    Closed 
     <p
       class="chakra-text css-14gt3bc"
     >
       2
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Passed
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Failed
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Abstained
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
     </p>
   </button>
 </div>
@@ -93,8 +66,7 @@ exports[`VotingStatusFilter.tsx component match to snapshot all closed proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    All
-     
+    All 
     <p
       class="chakra-text css-14gt3bc"
     >
@@ -105,8 +77,7 @@ exports[`VotingStatusFilter.tsx component match to snapshot all closed proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    Active
-     
+    Active 
     <p
       class="chakra-text css-14gt3bc"
     >
@@ -117,48 +88,23 @@ exports[`VotingStatusFilter.tsx component match to snapshot all closed proposals
     class="chakra-button css-19xffvm"
     type="button"
   >
-    Closed
+    Pending
      
+    <p
+      class="chakra-text css-14gt3bc"
+    >
+      0
+    </p>
+  </button>
+  <button
+    class="chakra-button css-19xffvm"
+    type="button"
+  >
+    Closed 
     <p
       class="chakra-text css-14gt3bc"
     >
       2
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Passed
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Failed
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
-    </p>
-  </button>
-  <button
-    class="chakra-button css-19xffvm"
-    type="button"
-  >
-    Abstained
-     
-    <p
-      class="chakra-text css-14gt3bc"
-    >
-      3
     </p>
   </button>
 </div>

--- a/src/models/voting.ts
+++ b/src/models/voting.ts
@@ -19,6 +19,7 @@ export enum VotingStatus {
   ALL = 'all',
   CLOSED = 'closed',
   ACTIVE = 'active',
+  PENDING = 'pending',
 }
 
 export enum VotingChoices {
@@ -39,6 +40,7 @@ export type VotingStatusChoices =
   | VotingStatus.ALL
   | VotingStatus.ACTIVE
   | VotingStatus.CLOSED
+  | VotingStatus.PENDING
   | VotingOutcomes.PASSED
   | VotingOutcomes.FAILED
   | VotingOutcomes.ABSTAINED

--- a/src/pages/voting/[votingSlug].tsx
+++ b/src/pages/voting/[votingSlug].tsx
@@ -184,7 +184,7 @@ const VotingDetail = () => {
       ) {
         setStateText(VotingOutcomes.FAILED)
       } else {
-        setStateText(VotingOutcomes.ABSTAINED)
+        setStateText(votingProposalDetails.choices[highestVotedIndex])
       }
     } else {
       setStateText(votingProposalDetails?.state)

--- a/src/pages/voting/index.tsx
+++ b/src/pages/voting/index.tsx
@@ -31,7 +31,7 @@ import { VotingProvider } from 'store/contexts/votingContext'
 import Layout from 'layout'
 
 const Voting = () => {
-  const pageSize = 30
+  const pageSize = 50
   const proposalCountData = useQuery(snapshotProposalCountQuery)
   const [totalVotingProposals, setTotalVotingProposals] = useState(0)
   const { pages, pagesCount, currentPage, isDisabled, setCurrentPage } =

--- a/src/theme/components/Button.ts
+++ b/src/theme/components/Button.ts
@@ -73,6 +73,30 @@ const Button = {
         bgColor: 'green.75',
       },
     },
+    outlineGray: {
+      borderRadius: '0.25rem',
+      border: '1px solid',
+      borderColor: 'gray.80',
+      bgColor: 'gray.80',
+      padding: '0px 4px',
+      h: '18px',
+      _hover: {
+        color: 'white',
+        bgColor: 'transparent',
+      },
+    },
+    outlinePurple: {
+      borderRadius: '0.25rem',
+      border: '1px solid',
+      borderColor: 'purple.70',
+      bg: 'rgba(126, 0, 204, 0.3)',
+      padding: '0px 4px',
+      h: '18px',
+      _hover: {
+        color: 'white',
+        bgColor: 'transparent',
+      },
+    },
     backButton: {
       borderRadius: '0.25rem',
       border: 'none',


### PR DESCRIPTION
## What changes

- updated the voting status to use the correct voting options from the snapshot
- updated voting status colors on the proposal card
  - Pending (gray button)
  - Active (green button)
  - Closed (purple button)
- update voting status filters (All, Pending, Active, Closed)
- changed proposal text from `Status` to `Result` if the proposal is already closed, if the proposal is pending or active, it will show the text `Status`
After:
![image](https://github.com/new-order-network/new-order-app-ui/assets/26428605/a3904353-c007-42dd-8ceb-68f39a3cf996)


## Screenshots (if applicable)
Before: 
- showing `Abstained` because this was used as a fallback for non-included voting options (included options were the default of snapshot which is `For`,`Against`, and `Abstained`)
<img width="365" alt="image" src="https://github.com/new-order-network/new-order-app-ui/assets/26428605/09e2fedb-8d56-43da-ae5e-6f435e7cebf4">

After:
![image](https://github.com/new-order-network/new-order-app-ui/assets/26428605/fa4dda2d-7927-4f77-beb0-95bc53e552cc)
